### PR TITLE
feat: cria página de detalhes do módulo com testes, view, facade e te…

### DIFF
--- a/pypro/base/templates/base/home.html
+++ b/pypro/base/templates/base/home.html
@@ -8,7 +8,7 @@
 				<div class="col-md-12">
 					<div class="card card-gray-light  mb-4">
 						<div class="container-fluid py-5">
-							<h2 class="display-5 fw-bold">Plataforma de Cursos - URBPY 🖥️ </h2>
+							<h2 class="display-5 fw-bold align-items-center">Plataforma - URBPY 🖥️ </h2>
 						
 							<h4 class="mt-5"> Entre na fila de espera</h4>
 							<form action="https://gmail.us15.list-manage.com/subscribe/post?u=298924e948797aa911794ac34&amp;id=9e35377035&amp;f_id=007aa3e1f0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="d-flex align-items-center gap-2 flex-wrap w-100 mt-3" target="_blank">

--- a/pypro/modulos/facade.py
+++ b/pypro/modulos/facade.py
@@ -9,3 +9,7 @@ def listar_modulos_ordenados() -> List[Modulo]:
 
     """
     return list(Modulo.objects.order_by('order').all())
+
+
+def encontrar_modulo(slug: str) -> Modulo:
+    return Modulo.objects.get(slug=slug)

--- a/pypro/modulos/templates/modulos/modulo_detalhe.html
+++ b/pypro/modulos/templates/modulos/modulo_detalhe.html
@@ -1,0 +1,21 @@
+{% extends 'base/base.html' %}
+{% load static %}
+{% block title %}{{modulo.titulo}}{% endblock title %}
+<meta name="description" content="{% block description %} Página com Detalhes do módulo{{ modulo.titulo }}{% endblock description%}">
+{% block body %}
+	<main class="container">
+		<div class="container">
+			<div class="row">		
+				<div class="col-md-12">
+                    <h1 class="mt-4 mb-3">{{ modulo.titulo }}</h1>
+					<dl>
+						<dt>Público</dt>
+                        <dd>{{ modulo.publico }}</dd>
+                        <dt>Descrição</dt>
+                        <dd>{{ modulo.descricao }}</dd>
+					</dl>
+				</div>
+			</div>				
+		</div>
+	</main>
+{% endblock body %}

--- a/pypro/modulos/tests/test_modulo_detalhe.py
+++ b/pypro/modulos/tests/test_modulo_detalhe.py
@@ -1,0 +1,30 @@
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+
+from pypro.django_assertions import assert_contains
+from pypro.modulos.models import Modulo
+
+
+@pytest.fixture
+def modulo(db):
+    return baker.make(Modulo)
+
+
+@pytest.fixture
+def resp(client, modulo):
+    resp = client.get(reverse('modulos:detalhe', kwargs={'slug': modulo.slug}))
+    return resp
+
+
+def test_titulos(resp, modulo:Modulo):
+    assert_contains(resp, modulo.titulo)
+
+
+def test_descricao(resp, modulo:Modulo):
+    assert_contains(resp, modulo.descricao)
+
+
+def test_publico(resp, modulo:Modulo):
+    assert_contains(resp, modulo.publico)
+

--- a/pypro/modulos/tests/test_modulo_detalhe.py
+++ b/pypro/modulos/tests/test_modulo_detalhe.py
@@ -17,14 +17,13 @@ def resp(client, modulo):
     return resp
 
 
-def test_titulos(resp, modulo:Modulo):
+def test_titulos(resp, modulo: Modulo):
     assert_contains(resp, modulo.titulo)
 
 
-def test_descricao(resp, modulo:Modulo):
+def test_descricao(resp, modulo: Modulo):
     assert_contains(resp, modulo.descricao)
 
 
-def test_publico(resp, modulo:Modulo):
+def test_publico(resp, modulo: Modulo):
     assert_contains(resp, modulo.publico)
-

--- a/pypro/modulos/views.py
+++ b/pypro/modulos/views.py
@@ -1,6 +1,8 @@
-# from django.shortcuts import render
+from django.shortcuts import render
 
-# Create your views here.
+from pypro.modulos import facade
+
 
 def detalhe(request, slug):
-    pass
+    modulo = facade.encontrar_modulo(slug)
+    return render(request, 'modulos/modulo_detalhe.html', {'modulo': modulo})


### PR DESCRIPTION
close #11 close #93

- Adiciona teste de exibição de título, descrição e público no módulo
- Cria view 'detalhe' no app modulos
- Implementa função `encontrar_modulo` no facade.py
- Cria template `modulo_detalhe.html` com exibição dos dados do módulo